### PR TITLE
Create temporary config file in the same directory as pyproject.toml

### DIFF
--- a/src/flake518/adapter.py
+++ b/src/flake518/adapter.py
@@ -223,7 +223,7 @@ def run(argv: Optional[_List[str]] = None) -> None:
         )
         update_configuration(config)
         with NamedTemporaryFile(
-            "w+t", prefix="flake518_", suffix=".cfg", delete=True
+            "x+t", prefix=".flake518_", suffix=".cfg", delete=True, dir=py_project.parent
         ) as handle:
             write_config_to_ini(config, handle)
             logger.debug(


### PR DESCRIPTION
`flake8` calculates exclude paths relative to its config file if they contain a `/`, so the temporary config file should be created in the project root i.e. the same directory as `pyproject.toml` and not e.g. in `/tmp`.

Fixes #3.