### PR TITLE
Fix typo in var name

### DIFF
--- a/src/flake518/adapter.py
+++ b/src/flake518/adapter.py
@@ -67,7 +67,7 @@ def _get_os_var_value(var_name: str) -> bool:
     var_value: Optional[str] = os.getenv(var_name)
 
     if var_value is not None:
-        return bool(flake518_dbg_env)
+        return bool(var_value)
     
     return False
 


### PR DESCRIPTION
In the latest release, when running `flake518` with the env variable `FLAKE518_KEEPFILE` set to `True`, I'm having the following error :

```
Traceback (most recent call last):
  File "C:\Users\remon\Miniconda3\envs\pytere\lib\runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "C:\Users\remon\Miniconda3\envs\pytere\lib\runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "C:\Users\remon\Miniconda3\envs\pytere\Scripts\flake518.exe\__main__.py", line 7, in <module>
  File "C:\Users\remon\Miniconda3\envs\pytere\lib\site-packages\flake518\__main__.py", line 33, in main
    run()
  File "C:\Users\remon\Miniconda3\envs\pytere\lib\site-packages\flake518\adapter.py", line 234, in run
    keep_file = _get_os_var_value("FLAKE518_KEEPFILE")
  File "C:\Users\remon\Miniconda3\envs\pytere\lib\site-packages\flake518\adapter.py", line 70, in _get_os_var_value
    return bool(flake518_dbg_env)
NameError: name 'flake518_dbg_env' is not defined
```

---

It seems to be a simple typo in the code.